### PR TITLE
new version of engagement hook url

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/config/rest/client/EngagementApiRestClient.java
+++ b/src/main/java/com/redhat/labs/lodestar/config/rest/client/EngagementApiRestClient.java
@@ -18,7 +18,7 @@ import java.util.List;
 public interface EngagementApiRestClient {
 
     @PUT
-    @Path("/api/v1/engagements/gitlab-webhooks")
+    @Path("/api/v2/engagements/gitlab-webhooks")
     Response updateWebhooks(List<GitlabHook> webhooks);
 
 }


### PR DESCRIPTION
- update url for webhook notification (only in use for v2)